### PR TITLE
fix: filter out acs: system-reserved tags to avoid InvalidTagKey

### DIFF
--- a/velero-plugin-alibabacloud/volume_snapshotter.go
+++ b/velero-plugin-alibabacloud/volume_snapshotter.go
@@ -165,7 +165,7 @@ func (b *VolumeSnapshotter) CreateVolumeFromSnapshot(snapshotID, volumeType, vol
 		return "", errors.Wrapf(err, "failed to describe snapshot %s", snapshotID)
 	}
 
-	tags := b.getTagsForCluster(snapInfo.Tags.Tag)
+	tags := b.restoreDiskTags(snapInfo.Tags.Tag)
 
 	// Use volumeAZ from parameter if provided, otherwise determine from snapshot tags or metadata
 	if volumeAZ == "" {
@@ -293,7 +293,7 @@ func (b *VolumeSnapshotter) CreateSnapshot(volumeID, volumeAZ string, tags map[s
 		volumeZoneID = tea.StringValue(volumeInfo.ZoneId)
 	}
 
-	newTags := b.getTagsWithVolumeZone(tags, volumeInfo.Tags.Tag, volumeZoneID)
+	newTags := b.snapshotTags(tags, volumeInfo.Tags.Tag, volumeZoneID)
 	if len(newTags) > 0 {
 		req.Tag = newTags
 	}
@@ -441,49 +441,84 @@ func (b *VolumeSnapshotter) describeVolume(volumeID string, volumeAZ string) (*e
 	return res.Body.Disks.Disk[0], nil
 }
 
-// getTagsForCluster processes snapshot tags and adds cluster-specific tags for restored volumes
-func (b *VolumeSnapshotter) getTagsForCluster(snapshotTags []*ecs20140526.DescribeSnapshotsResponseBodySnapshotsSnapshotTagsTag) []*ecs20140526.CreateDiskRequestTag {
+// tagKV is an intermediate representation for tag key-value pairs,
+// decoupled from SDK-specific tag types.
+type tagKV struct {
+	key   string
+	value string
+}
+
+// copyTags filters source tags, skipping nil entries, system-reserved keys (acs:*),
+// and any key for which skipKey returns true.
+func copyTags(keys []*string, values []*string, skipKey func(string) bool) []tagKV {
+	var result []tagKV
+	for i := range keys {
+		if keys[i] == nil {
+			continue
+		}
+		k := tea.StringValue(keys[i])
+		if isInvalidTagKey(k) || skipKey(k) {
+			continue
+		}
+		v := ""
+		if values[i] != nil {
+			v = tea.StringValue(values[i])
+		}
+		result = append(result, tagKV{key: k, value: v})
+	}
+	return result
+}
+
+// restoreDiskTags builds tags for CreateDisk when restoring a volume from snapshot.
+// It adds current cluster ownership tags and copies snapshot tags, skipping old cluster tags.
+func (b *VolumeSnapshotter) restoreDiskTags(snapshotTags []*ecs20140526.DescribeSnapshotsResponseBodySnapshotsSnapshotTagsTag) []*ecs20140526.CreateDiskRequestTag {
 	var result []*ecs20140526.CreateDiskRequestTag
 
-	clusterName, haveACKClusterNameEnvVar := os.LookupEnv(ackClusterNameKey)
+	clusterName, haveClusterName := os.LookupEnv(ackClusterNameKey)
 
-	if haveACKClusterNameEnvVar {
+	if haveClusterName {
 		result = append(result, &ecs20140526.CreateDiskRequestTag{
 			Key:   tea.String("kubernetes.io/cluster/" + clusterName),
 			Value: tea.String("owned"),
 		})
-
 		result = append(result, &ecs20140526.CreateDiskRequestTag{
 			Key:   tea.String("KubernetesCluster"),
 			Value: tea.String(clusterName),
 		})
 	}
 
-	for _, tag := range snapshotTags {
-		if tag == nil {
-			continue
+	// Extract keys and values from snapshot tags
+	keys := make([]*string, len(snapshotTags))
+	values := make([]*string, len(snapshotTags))
+	for i, tag := range snapshotTags {
+		if tag != nil {
+			keys[i] = tag.TagKey
+			values[i] = tag.TagValue
 		}
-		tagKey := tea.StringValue(tag.TagKey)
-		if haveACKClusterNameEnvVar && (strings.HasPrefix(tagKey, "kubernetes.io/cluster/") || tagKey == "KubernetesCluster") {
-			// if the ACK_CLUSTER_NAME variable is found we want current cluster
-			// to overwrite the old ownership on volumes
-			continue
-		}
+	}
 
+	copied := copyTags(keys, values, func(k string) bool {
+		// Skip old cluster ownership tags when we have a new cluster name
+		return haveClusterName && (strings.HasPrefix(k, "kubernetes.io/cluster/") || k == "KubernetesCluster")
+	})
+
+	for _, t := range copied {
 		result = append(result, &ecs20140526.CreateDiskRequestTag{
-			Key:   tag.TagKey,
-			Value: tag.TagValue,
+			Key:   tea.String(t.key),
+			Value: tea.String(t.value),
 		})
 	}
 
 	return result
 }
 
-// getTags processes Velero tags and volume tags to create snapshot tags
-func (b *VolumeSnapshotter) getTags(veleroTags map[string]string, volumeTags []*ecs20140526.DescribeDisksResponseBodyDisksDiskTagsTag) []*ecs20140526.CreateSnapshotRequestTag {
+// snapshotTags builds tags for CreateSnapshot when backing up a volume.
+// It starts with Velero-assigned tags, then copies volume tags (Velero tags take precedence on conflict),
+// and appends the original volume AZ tag if not already present.
+func (b *VolumeSnapshotter) snapshotTags(veleroTags map[string]string, volumeTags []*ecs20140526.DescribeDisksResponseBodyDisksDiskTagsTag, volumeZoneID string) []*ecs20140526.CreateSnapshotRequestTag {
 	var result []*ecs20140526.CreateSnapshotRequestTag
 
-	// set Velero-assigned tags
+	// Velero-assigned tags first (highest priority)
 	for k, v := range veleroTags {
 		result = append(result, &ecs20140526.CreateSnapshotRequestTag{
 			Key:   tea.String(k),
@@ -491,47 +526,43 @@ func (b *VolumeSnapshotter) getTags(veleroTags map[string]string, volumeTags []*
 		})
 	}
 
-	// copy tags from volume to snapshot
-	for _, tag := range volumeTags {
-		if tag == nil {
-			continue
-		}
-		tagKey := tea.StringValue(tag.TagKey)
-		// we want current Velero-assigned tags to overwrite any older versions
-		// of them that may exist due to prior snapshots/restores
-		if _, found := veleroTags[tagKey]; found {
-			continue
-		}
-
-		result = append(result, &ecs20140526.CreateSnapshotRequestTag{
-			Key:   tag.TagKey,
-			Value: tag.TagValue,
-		})
-	}
-
-	return result
-}
-
-// getTagsWithVolumeZone processes Velero tags and volume tags to create snapshot tags,
-// and adds original volume AZ tag if not present
-func (b *VolumeSnapshotter) getTagsWithVolumeZone(veleroTags map[string]string, volumeTags []*ecs20140526.DescribeDisksResponseBodyDisksDiskTagsTag, volumeZoneID string) []*ecs20140526.CreateSnapshotRequestTag {
-	result := b.getTags(veleroTags, volumeTags)
-
-	// Check if original volume AZ tag already exists in result
-	hasOriginalVolumeAZTag := false
-	for _, tag := range result {
-		if tag != nil && tea.StringValue(tag.Key) == originalVolumeAZTagKey {
-			hasOriginalVolumeAZTag = true
-			break
+	// Extract keys and values from volume tags
+	keys := make([]*string, len(volumeTags))
+	values := make([]*string, len(volumeTags))
+	for i, tag := range volumeTags {
+		if tag != nil {
+			keys[i] = tag.TagKey
+			values[i] = tag.TagValue
 		}
 	}
 
-	// If not present and volumeZoneID is available, add it
-	if !hasOriginalVolumeAZTag && volumeZoneID != "" {
+	copied := copyTags(keys, values, func(k string) bool {
+		_, found := veleroTags[k]
+		return found
+	})
+
+	for _, t := range copied {
 		result = append(result, &ecs20140526.CreateSnapshotRequestTag{
-			Key:   tea.String(originalVolumeAZTagKey),
-			Value: tea.String(volumeZoneID),
+			Key:   tea.String(t.key),
+			Value: tea.String(t.value),
 		})
+	}
+
+	// Append original volume AZ tag if not already present
+	if volumeZoneID != "" {
+		hasAZTag := false
+		for _, tag := range result {
+			if tag != nil && tea.StringValue(tag.Key) == originalVolumeAZTagKey {
+				hasAZTag = true
+				break
+			}
+		}
+		if !hasAZTag {
+			result = append(result, &ecs20140526.CreateSnapshotRequestTag{
+				Key:   tea.String(originalVolumeAZTagKey),
+				Value: tea.String(volumeZoneID),
+			})
+		}
 	}
 
 	return result
@@ -715,6 +746,12 @@ func setEBSDiskID(pv *v1.PersistentVolume, diskID string) error {
 		return nil
 	}
 	return errors.New("spec.CSI or spec.FlexVolume not found")
+}
+
+// isInvalidTagKey returns true if the tag key would be rejected by ECS Create* APIs.
+// Keys starting with "acs:" are system-reserved and cause InvalidTagKey.Malformed errors.
+func isInvalidTagKey(key string) bool {
+	return strings.HasPrefix(strings.ToLower(key), "acs:")
 }
 
 // getPerformanceLevelFromIOPS converts IOPS value to Alibaba Cloud Performance Level

--- a/velero-plugin-alibabacloud/volume_snapshotter_test.go
+++ b/velero-plugin-alibabacloud/volume_snapshotter_test.go
@@ -233,7 +233,7 @@ func TestSetVolumeIDNoZone(t *testing.T) {
 	assert.Equal(t, "vol-updated", diskID)
 }
 
-func TestGetTagsForCluster(t *testing.T) {
+func TestRestoreDiskTags(t *testing.T) {
 	tests := []struct {
 		name         string
 		isNameSet    bool
@@ -303,7 +303,7 @@ func TestGetTagsForCluster(t *testing.T) {
 			if test.isNameSet {
 				t.Setenv(ackClusterNameKey, "current-cluster")
 			}
-			res := b.getTagsForCluster(test.snapshotTags)
+			res := b.restoreDiskTags(test.snapshotTags)
 
 			sort.Slice(res, func(i, j int) bool {
 				return tea.StringValue(res[i].Key) < tea.StringValue(res[j].Key)
@@ -383,7 +383,7 @@ func TestGetPerformanceLevelFromIOPS(t *testing.T) {
 	}
 }
 
-func TestGetTags(t *testing.T) {
+func TestSnapshotTags(t *testing.T) {
 	tests := []struct {
 		name       string
 		veleroTags map[string]string
@@ -452,7 +452,7 @@ func TestGetTags(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			b := newVolumeSnapshotter(newTestLogger())
-			res := b.getTags(test.veleroTags, test.volumeTags)
+			res := b.snapshotTags(test.veleroTags, test.volumeTags, "")
 
 			sort.Slice(res, func(i, j int) bool {
 				return tea.StringValue(res[i].Key) < tea.StringValue(res[j].Key)
@@ -1026,7 +1026,7 @@ func TestDescribeVolume(t *testing.T) {
 	}
 }
 
-// TestGetTagsWithVolumeZone tests the getTagsWithVolumeZone function
+// TestGetTagsWithVolumeZone tests the snapshotTags function
 func TestGetTagsWithVolumeZone(t *testing.T) {
 	tests := []struct {
 		name          string
@@ -1085,7 +1085,7 @@ func TestGetTagsWithVolumeZone(t *testing.T) {
 				log: newTestLogger(),
 			}
 
-			result := b.getTagsWithVolumeZone(test.veleroTags, test.volumeTags, test.volumeZoneID)
+			result := b.snapshotTags(test.veleroTags, test.volumeTags, test.volumeZoneID)
 
 			assert.Equal(t, test.expectedCount, len(result))
 
@@ -1329,4 +1329,71 @@ func TestDetermineVolumeAZ(t *testing.T) {
 			assert.Equal(t, test.expectedZone, zone)
 		})
 	}
+}
+
+func TestIsInvalidTagKey(t *testing.T) {
+	tests := []struct {
+		key      string
+		expected bool
+	}{
+		{"acs:ecs:createdBy", true},
+		{"ACS:something", true},
+		{"Acs:Tag", true},
+		{"acs:", true},
+		{"kubernetes.io/cluster/my-cluster", false},
+		{"velero.io/backup", false},
+		{"", false},
+		{"acs-something", false},
+		{"aliyun-tag", false},
+	}
+
+	for _, test := range tests {
+		t.Run(test.key, func(t *testing.T) {
+			assert.Equal(t, test.expected, isInvalidTagKey(test.key))
+		})
+	}
+}
+
+func TestSnapshotTagsFiltersInvalidKeys(t *testing.T) {
+	b := newVolumeSnapshotter(newTestLogger())
+
+	veleroTags := map[string]string{
+		"velero-key": "velero-val",
+	}
+	volumeTags := []*ecs20140526.DescribeDisksResponseBodyDisksDiskTagsTag{
+		{TagKey: tea.String("normal-key"), TagValue: tea.String("normal-val")},
+		{TagKey: tea.String("acs:ecs:createdBy"), TagValue: tea.String("system-val")},
+		{TagKey: tea.String("acs:rm:rgId"), TagValue: tea.String("system-val2")},
+	}
+
+	res := b.snapshotTags(veleroTags, volumeTags, "")
+
+	// Should only have velero-key and normal-key, not the acs: prefixed tags
+	assert.Equal(t, 2, len(res))
+
+	keys := make(map[string]string)
+	for _, tag := range res {
+		keys[tea.StringValue(tag.Key)] = tea.StringValue(tag.Value)
+	}
+	assert.Equal(t, "velero-val", keys["velero-key"])
+	assert.Equal(t, "normal-val", keys["normal-key"])
+	assert.Empty(t, keys["acs:ecs:createdBy"])
+	assert.Empty(t, keys["acs:rm:rgId"])
+}
+
+func TestRestoreDiskTagsFiltersInvalidKeys(t *testing.T) {
+	b := newVolumeSnapshotter(newTestLogger())
+
+	snapshotTags := []*ecs20140526.DescribeSnapshotsResponseBodySnapshotsSnapshotTagsTag{
+		{TagKey: tea.String("normal-key"), TagValue: tea.String("normal-val")},
+		{TagKey: tea.String("acs:ecs:createdBy"), TagValue: tea.String("system-val")},
+		{TagKey: tea.String("acs:rm:rgId"), TagValue: tea.String("system-val2")},
+	}
+
+	res := b.restoreDiskTags(snapshotTags)
+
+	// Should only have normal-key, not the acs: prefixed tags
+	assert.Equal(t, 1, len(res))
+	assert.Equal(t, "normal-key", tea.StringValue(res[0].Key))
+	assert.Equal(t, "normal-val", tea.StringValue(res[0].Value))
 }


### PR DESCRIPTION


ECS backend may add system-reserved tags with 'acs:' prefix to volumes/snapshots (e.g. acs:ecs:createdBy). These tags are returned by Describe* APIs but rejected by Create* APIs with InvalidTagKey.Malformed error.

Also refactored tag functions:
- Renamed getTags/getTagsWithVolumeZone -> snapshotTags (backup direction)
- Renamed getTagsForCluster -> restoreDiskTags (restore direction)
- Extracted common copyTags helper to reduce duplication