### PR TITLE
fix: use godotenv.Read for per-location credential isolation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .go
 _output
 .idea
+.agents/skills/local
 _output
 coverage.out

--- a/velero-plugin-alibabacloud/common.go
+++ b/velero-plugin-alibabacloud/common.go
@@ -36,6 +36,13 @@ const (
 	// Constants for volume ID conversion
 	OriginStr = "volumeId"
 	TargetStr = "VolumeId"
+
+	// Credential environment variable / file key names
+	envAccessKeyID     = "ALIBABA_CLOUD_ACCESS_KEY_ID"
+	envAccessKeySecret = "ALIBABA_CLOUD_ACCESS_KEY_SECRET"
+	envStsToken        = "ALIBABA_CLOUD_ACCESS_STS_TOKEN"
+	envRamRole         = "ALIBABA_CLOUD_RAM_ROLE"
+	envCredFile        = "ALIBABA_CLOUD_CREDENTIALS_FILE"
 )
 
 var validConfigKeys = []string{
@@ -47,26 +54,25 @@ var validConfigKeys = []string{
 	credFileConfigKey,
 }
 
-// loadCredentialFileFromEnv loads environment variables from a credentials file.
-// The file path can be specified either via config["credentialsFile"] or the
-// ALIBABA_CLOUD_CREDENTIALS_FILE environment variable. Config takes precedence.
-func loadCredentialFileFromEnv(config map[string]string) error {
-	var filePath string
+// getCredFilePath returns the credentials file path from config or environment.
+// Config takes precedence over ALIBABA_CLOUD_CREDENTIALS_FILE env var.
+func getCredFilePath(config map[string]string) string {
 	if config != nil && config[credFileConfigKey] != "" {
-		filePath = config[credFileConfigKey]
-	} else {
-		// Deprecated
-		filePath = os.Getenv("ALIBABA_CLOUD_CREDENTIALS_FILE")
+		return config[credFileConfigKey]
 	}
-	if filePath == "" {
-		return nil
-	}
+	// Deprecated
+	return os.Getenv(envCredFile)
+}
 
-	if err := godotenv.Overload(filePath); err != nil {
-		return errors.Wrapf(err, "error loading credientials file (%s)", filePath)
+// readCredentialFile reads credentials from a file without polluting process-wide
+// environment variables. This enables per-location credential isolation when
+// BSL and VSL reference different Kubernetes Secrets via spec.credential.
+func readCredentialFile(filePath string) (map[string]string, error) {
+	envMap, err := godotenv.Read(filePath)
+	if err != nil {
+		return nil, errors.Wrapf(err, "error loading credentials file (%s)", filePath)
 	}
-
-	return nil
+	return envMap, nil
 }
 
 // getOssEndpoint:
@@ -173,68 +179,70 @@ func veleroForAck(config map[string]string) bool {
 	return !(strings.ToLower(os.Getenv("VELERO_FOR_ACK")) == "false")
 }
 
-// getCredentials retrieves OSS credentials based on the environment and configuration.
-// It supports multiple authentication methods with the following priority order:
+// getCredentials retrieves credentials based on the environment and configuration.
+// It supports per-location credential isolation: each BSL/VSL can reference a different
+// Kubernetes Secret via spec.credential, and Velero injects the file path into the
+// config map under the credFileConfigKey key.
 //
-// 1. AccessKey credentials (highest priority):
-//   - Load from file (if ALIBABA_CLOUD_CREDENTIALS_FILE is set) and/or environment variables
-//   - Environment variables: ALIBABA_CLOUD_ACCESS_KEY_ID, ALIBABA_CLOUD_ACCESS_KEY_SECRET
-//   - Optional: ALIBABA_CLOUD_ACCESS_STS_TOKEN
-//   - If both AccessKey ID and Secret are provided, they take precedence over RAM role
+// Credential resolution priority order:
 //
-// 2. Custom RAM Role (via environment variable):
-//   - Environment variable: ALIBABA_CLOUD_RAM_ROLE
-//   - Allows specifying a custom RAM role name instead of using the ECS instance's default role
-//   - Works in both ACK and non-ACK environments
-//   - The function will use this role to obtain STS credentials via getSTSAK()
+//  1. Credentials file (per-location, highest priority):
+//     - Config key: credFileConfigKey (injected by Velero when spec.credential is set)
+//     - Fallback: envCredFile environment variable
+//     - File is read without setting process-wide env vars (isolation-safe)
+//     - File format: dotenv key=value pairs (envAccessKeyID, envAccessKeySecret, etc.)
 //
-// 3. ECS Instance RAM Role (ACK environment fallback):
-//   - For ACK environments: automatically detect the RAM role from ECS metadata
-//   - Only used if no AccessKey credentials and no custom RAM role are provided
-//   - Requires the ECS instance to have a RAM role attached
+//  2. Process environment variables (shared, lower priority):
+//     - envAccessKeyID, envAccessKeySecret
+//     - Optional: envStsToken
+//     - Only consulted when no credentials file is available
 //
-// 4. Error (non-ACK environment without credentials):
-//   - For non-ACK environments: returns error if no AccessKey and no custom RAM role are provided
+//  3. Custom RAM Role (via credentials file or environment variable):
+//     - envRamRole — custom RAM role name
+//     - Used to obtain STS credentials via ECS metadata service
 //
-// Parameters:
-//   - config: configuration map that may contain:
-//   - "credentialsFile": path to credentials file (takes precedence over ALIBABA_CLOUD_CREDENTIALS_FILE env var)
-//   - "notOnECS": if set to "true", indicates not running on ECS (affects RAM role detection)
+//  4. ECS Instance RAM Role (ACK environment fallback):
+//     - Automatically detected from ECS metadata service
+//     - Only used if no AccessKey credentials and no custom RAM role are provided
 //
-// Returns:
-//   - ossCredentials: contains accessKeyID, accessKeySecret, stsToken, and ramRole
-//   - error: if credentials cannot be obtained
+//  5. Error (non-ACK environment without any credentials)
 func getCredentials(config map[string]string) (*ossCredentials, error) {
 	cred := &ossCredentials{}
 
-	// Step 1: Load credentials from file if specified (this may set env vars)
-	if err := loadCredentialFileFromEnv(config); err != nil {
-		return nil, err
+	// Step 1: Try to load credentials from a per-location file.
+	// This does NOT set process-wide env vars, enabling BSL/VSL credential isolation.
+	if filePath := getCredFilePath(config); filePath != "" {
+		envMap, err := readCredentialFile(filePath)
+		if err != nil {
+			return nil, err
+		}
+		cred.accessKeyID = envMap[envAccessKeyID]
+		cred.accessKeySecret = envMap[envAccessKeySecret]
+		cred.stsToken = envMap[envStsToken]
+		cred.ramRole = envMap[envRamRole]
+	} else {
+		// Step 2: No credentials file — fall back to process environment variables.
+		cred.accessKeyID = os.Getenv(envAccessKeyID)
+		cred.accessKeySecret = os.Getenv(envAccessKeySecret)
+		cred.stsToken = os.Getenv(envStsToken)
+		cred.ramRole = os.Getenv(envRamRole)
 	}
 
-	// Step 2: Get credentials from environment variables
-	// These may be set by loadCredentialFileFromEnv or directly by the user
-	cred.accessKeyID = os.Getenv("ALIBABA_CLOUD_ACCESS_KEY_ID")
-	cred.accessKeySecret = os.Getenv("ALIBABA_CLOUD_ACCESS_KEY_SECRET")
-	cred.stsToken = os.Getenv("ALIBABA_CLOUD_ACCESS_STS_TOKEN") // Token may be empty
-	cred.ramRole = os.Getenv("ALIBABA_CLOUD_RAM_ROLE")          // Custom RAM role name
-
-	// Step 3: If we have both accessKeyID and accessKeySecret, use them directly
-	// AccessKey credentials take precedence over RAM role
+	// Step 3: If we have both accessKeyID and accessKeySecret, use them directly.
+	// AccessKey credentials take precedence over RAM role.
 	if len(cred.accessKeyID) != 0 && len(cred.accessKeySecret) != 0 {
 		cred.ramRole = ""
 		return cred, nil
 	}
 
-	// Step 4: Handle RAM role authentication
-	// If no AccessKey credentials are available, try to use RAM role
+	// Step 4: Handle RAM role authentication.
+	// If no AccessKey credentials are available, try to use RAM role.
 	if !veleroForAck(config) && cred.ramRole == "" {
-		// For non-ACK environment: if no AccessKey and no custom RAM role, return error
-		return nil, errors.Errorf("ALIBABA_CLOUD_ACCESS_KEY_ID or ALIBABA_CLOUD_ACCESS_KEY_SECRET environment variable is not set")
+		return nil, errors.Errorf("%s or %s environment variable is not set", envAccessKeyID, envAccessKeySecret)
 	}
 
 	// Determine which RAM role to use:
-	// - If custom RAM role is specified via ALIBABA_CLOUD_RAM_ROLE, use it
+	// - If custom RAM role is specified (from file or env), use it
 	// - Otherwise, for ACK environment, try to get RAM role from ECS metadata
 	if cred.ramRole == "" {
 		ramRole, err := getRamRole()

--- a/velero-plugin-alibabacloud/common_test.go
+++ b/velero-plugin-alibabacloud/common_test.go
@@ -227,7 +227,7 @@ ALIBABA_CLOUD_ACCESS_STS_TOKEN=config-file-token
 				t.Setenv("ALIBABA_CLOUD_ACCESS_STS_TOKEN", "")
 				return nil
 			},
-			expectedError: "error loading credientials file",
+			expectedError: "error loading credentials file",
 		},
 		{
 			name:   "error: invalid credential file from config",
@@ -239,7 +239,7 @@ ALIBABA_CLOUD_ACCESS_STS_TOKEN=config-file-token
 				t.Setenv("ALIBABA_CLOUD_ACCESS_STS_TOKEN", "")
 				return nil
 			},
-			expectedError: "error loading credientials file",
+			expectedError: "error loading credentials file",
 		},
 		{
 			name:   "success: custom RAM role in non-ACK environment",
@@ -289,6 +289,9 @@ ALIBABA_CLOUD_ACCESS_STS_TOKEN=config-file-token
 				require.NoError(t, err)
 
 				t.Setenv("ALIBABA_CLOUD_CREDENTIALS_FILE", credFile)
+				t.Setenv("ALIBABA_CLOUD_ACCESS_KEY_ID", "")
+				t.Setenv("ALIBABA_CLOUD_ACCESS_KEY_SECRET", "")
+				t.Setenv("ALIBABA_CLOUD_ACCESS_STS_TOKEN", "")
 				// Cleanup after test
 				t.Cleanup(func() {
 					os.RemoveAll(tmpDir)
@@ -298,6 +301,277 @@ ALIBABA_CLOUD_ACCESS_STS_TOKEN=config-file-token
 			// This will fail because getSTSAK requires real ECS metadata service,
 			// but it verifies that the custom RAM role from file is used
 			expectedError: "Failed to get sts token from ram role FileCustomRole",
+		},
+		// ============================================================
+		// Isolation tests: verify per-location credential separation
+		// ============================================================
+		{
+			name:   "isolation: credentialsFile does not pollute process env vars",
+			config: nil,
+			setupEnv: func(t *testing.T) map[string]string {
+				// Create a credential file with specific AK/SK
+				tmpDir, err := os.MkdirTemp("", "test-cred-isolation")
+				require.NoError(t, err)
+
+				credFile := filepath.Join(tmpDir, "credentials")
+				err = os.WriteFile(credFile, []byte(`ALIBABA_CLOUD_ACCESS_KEY_ID=file-isolated-ak
+ALIBABA_CLOUD_ACCESS_KEY_SECRET=file-isolated-sk
+`), 0644)
+				require.NoError(t, err)
+
+				// Set process env vars to different values
+				t.Setenv("ALIBABA_CLOUD_CREDENTIALS_FILE", "")
+				t.Setenv("ALIBABA_CLOUD_ACCESS_KEY_ID", "process-env-ak")
+				t.Setenv("ALIBABA_CLOUD_ACCESS_KEY_SECRET", "process-env-sk")
+				t.Setenv("ALIBABA_CLOUD_ACCESS_STS_TOKEN", "")
+
+				t.Cleanup(func() {
+					os.RemoveAll(tmpDir)
+				})
+
+				return map[string]string{"credentialsFile": credFile}
+			},
+			validateCred: func(t *testing.T, cred *ossCredentials) {
+				// Should use file credentials, not process env
+				assert.Equal(t, "file-isolated-ak", cred.accessKeyID)
+				assert.Equal(t, "file-isolated-sk", cred.accessKeySecret)
+				// Verify process env vars were NOT overwritten
+				assert.Equal(t, "process-env-ak", os.Getenv("ALIBABA_CLOUD_ACCESS_KEY_ID"),
+					"process env vars must not be polluted by credentialsFile loading")
+				assert.Equal(t, "process-env-sk", os.Getenv("ALIBABA_CLOUD_ACCESS_KEY_SECRET"),
+					"process env vars must not be polluted by credentialsFile loading")
+			},
+		},
+		{
+			name:   "isolation: no credentialsFile falls back to process env vars",
+			config: map[string]string{"notOnECS": "true"},
+			setupEnv: func(t *testing.T) map[string]string {
+				t.Setenv("ALIBABA_CLOUD_CREDENTIALS_FILE", "")
+				t.Setenv("ALIBABA_CLOUD_ACCESS_KEY_ID", "fallback-ak")
+				t.Setenv("ALIBABA_CLOUD_ACCESS_KEY_SECRET", "fallback-sk")
+				t.Setenv("ALIBABA_CLOUD_ACCESS_STS_TOKEN", "")
+				return nil
+			},
+			validateCred: func(t *testing.T, cred *ossCredentials) {
+				assert.Equal(t, "fallback-ak", cred.accessKeyID)
+				assert.Equal(t, "fallback-sk", cred.accessKeySecret)
+			},
+		},
+		{
+			name:   "isolation: BSL with file-A then VSL with file-B get different credentials",
+			config: nil, // will be set per-call below
+			setupEnv: func(t *testing.T) map[string]string {
+				// This test simulates sequential BSL and VSL Init calls.
+				// We call getCredentials twice with different files and verify isolation.
+				tmpDir, err := os.MkdirTemp("", "test-bsl-vsl-isolation")
+				require.NoError(t, err)
+
+				bslFile := filepath.Join(tmpDir, "bsl-credentials")
+				err = os.WriteFile(bslFile, []byte(`ALIBABA_CLOUD_ACCESS_KEY_ID=bsl-ak
+ALIBABA_CLOUD_ACCESS_KEY_SECRET=bsl-sk
+`), 0644)
+				require.NoError(t, err)
+
+				vslFile := filepath.Join(tmpDir, "vsl-credentials")
+				err = os.WriteFile(vslFile, []byte(`ALIBABA_CLOUD_ACCESS_KEY_ID=vsl-ak
+ALIBABA_CLOUD_ACCESS_KEY_SECRET=vsl-sk
+`), 0644)
+				require.NoError(t, err)
+
+				// Clear env to ensure no interference
+				t.Setenv("ALIBABA_CLOUD_CREDENTIALS_FILE", "")
+				t.Setenv("ALIBABA_CLOUD_ACCESS_KEY_ID", "")
+				t.Setenv("ALIBABA_CLOUD_ACCESS_KEY_SECRET", "")
+				t.Setenv("ALIBABA_CLOUD_ACCESS_STS_TOKEN", "")
+
+				t.Cleanup(func() { os.RemoveAll(tmpDir) })
+
+				// Call BSL
+				bslCred, err := getCredentials(map[string]string{"credentialsFile": bslFile})
+				require.NoError(t, err)
+				assert.Equal(t, "bsl-ak", bslCred.accessKeyID)
+				assert.Equal(t, "bsl-sk", bslCred.accessKeySecret)
+
+				// Call VSL — must get different credentials
+				vslCred, err := getCredentials(map[string]string{"credentialsFile": vslFile})
+				require.NoError(t, err)
+				assert.Equal(t, "vsl-ak", vslCred.accessKeyID)
+				assert.Equal(t, "vsl-sk", vslCred.accessKeySecret)
+
+				// Verify env vars not polluted by either call
+				assert.Empty(t, os.Getenv("ALIBABA_CLOUD_ACCESS_KEY_ID"),
+					"env must remain empty after file-based credential loading")
+
+				// Return nil config — the actual test case assertion is done above
+				// We use validateCred=nil and no expectedError to just pass
+				return map[string]string{"notOnECS": "true", "credentialsFile": bslFile}
+			},
+			validateCred: func(t *testing.T, cred *ossCredentials) {
+				// The main assertions are in setupEnv above; this is just the final call
+				assert.Equal(t, "bsl-ak", cred.accessKeyID)
+			},
+		},
+		// ============================================================
+		// Breaking change tests: spec.credential does NOT leak to other locations
+		// ============================================================
+		{
+			name:   "breaking: BSL credentialsFile does not leak AK to VSL without file (non-ACK)",
+			config: nil,
+			setupEnv: func(t *testing.T) map[string]string {
+				// Simulate: BSL has a credentialsFile with AK/SK
+				tmpDir, err := os.MkdirTemp("", "test-no-leak")
+				require.NoError(t, err)
+
+				bslFile := filepath.Join(tmpDir, "bsl-credentials")
+				err = os.WriteFile(bslFile, []byte(`ALIBABA_CLOUD_ACCESS_KEY_ID=bsl-ak
+ALIBABA_CLOUD_ACCESS_KEY_SECRET=bsl-sk
+`), 0644)
+				require.NoError(t, err)
+
+				// Clear all env vars
+				t.Setenv("ALIBABA_CLOUD_CREDENTIALS_FILE", "")
+				t.Setenv("ALIBABA_CLOUD_ACCESS_KEY_ID", "")
+				t.Setenv("ALIBABA_CLOUD_ACCESS_KEY_SECRET", "")
+				t.Setenv("ALIBABA_CLOUD_ACCESS_STS_TOKEN", "")
+				t.Setenv("ALIBABA_CLOUD_RAM_ROLE", "")
+
+				t.Cleanup(func() { os.RemoveAll(tmpDir) })
+
+				// BSL Init: loads file credentials successfully
+				bslCred, err := getCredentials(map[string]string{"credentialsFile": bslFile})
+				require.NoError(t, err)
+				assert.Equal(t, "bsl-ak", bslCred.accessKeyID)
+
+				// VSL Init: no credentialsFile, no env vars, non-ACK → must FAIL
+				// (previously this would succeed by picking up BSL's leaked env vars)
+				return map[string]string{"notOnECS": "true"}
+			},
+			expectedError: "ALIBABA_CLOUD_ACCESS_KEY_ID or ALIBABA_CLOUD_ACCESS_KEY_SECRET environment variable is not set",
+		},
+		{
+			name:   "breaking: credentialsFile with partial AK only does not combine with env SK",
+			config: nil,
+			setupEnv: func(t *testing.T) map[string]string {
+				// File has only AK, env has SK — these should NOT be combined.
+				// The file path takes precedence: credentials come entirely from file.
+				tmpDir, err := os.MkdirTemp("", "test-partial-file")
+				require.NoError(t, err)
+
+				credFile := filepath.Join(tmpDir, "credentials")
+				err = os.WriteFile(credFile, []byte(`ALIBABA_CLOUD_ACCESS_KEY_ID=file-ak-only
+`), 0644)
+				require.NoError(t, err)
+
+				t.Setenv("ALIBABA_CLOUD_CREDENTIALS_FILE", "")
+				t.Setenv("ALIBABA_CLOUD_ACCESS_KEY_ID", "")
+				t.Setenv("ALIBABA_CLOUD_ACCESS_KEY_SECRET", "env-sk-should-not-combine")
+				t.Setenv("ALIBABA_CLOUD_ACCESS_STS_TOKEN", "")
+				t.Setenv("ALIBABA_CLOUD_RAM_ROLE", "")
+
+				t.Cleanup(func() { os.RemoveAll(tmpDir) })
+
+				// When credentialsFile is used, ONLY file contents matter.
+				// Incomplete credentials (AK without SK) from file should not be
+				// supplemented by env vars — the file is authoritative for that location.
+				return map[string]string{"credentialsFile": credFile, "notOnECS": "true"}
+			},
+			// AK from file but no SK → incomplete → falls through to RAM role check → fails (non-ACK)
+			expectedError: "ALIBABA_CLOUD_ACCESS_KEY_ID or ALIBABA_CLOUD_ACCESS_KEY_SECRET environment variable is not set",
+		},
+		// ============================================================
+		// Backward compatibility: shared env var path still works
+		// ============================================================
+		{
+			name:   "compat: shared env vars work for both BSL and VSL (no credentialsFile)",
+			config: nil,
+			setupEnv: func(t *testing.T) map[string]string {
+				// Shared credential via env vars — the common case
+				t.Setenv("ALIBABA_CLOUD_CREDENTIALS_FILE", "")
+				t.Setenv("ALIBABA_CLOUD_ACCESS_KEY_ID", "shared-ak")
+				t.Setenv("ALIBABA_CLOUD_ACCESS_KEY_SECRET", "shared-sk")
+				t.Setenv("ALIBABA_CLOUD_ACCESS_STS_TOKEN", "shared-token")
+
+				// Simulate BSL and VSL both calling getCredentials with no file
+				bslCred, err := getCredentials(map[string]string{"notOnECS": "true"})
+				require.NoError(t, err)
+				assert.Equal(t, "shared-ak", bslCred.accessKeyID)
+				assert.Equal(t, "shared-sk", bslCred.accessKeySecret)
+				assert.Equal(t, "shared-token", bslCred.stsToken)
+
+				vslCred, err := getCredentials(map[string]string{"notOnECS": "true"})
+				require.NoError(t, err)
+				assert.Equal(t, "shared-ak", vslCred.accessKeyID)
+				assert.Equal(t, "shared-sk", vslCred.accessKeySecret)
+				assert.Equal(t, "shared-token", vslCred.stsToken)
+
+				return map[string]string{"notOnECS": "true"}
+			},
+			validateCred: func(t *testing.T, cred *ossCredentials) {
+				assert.Equal(t, "shared-ak", cred.accessKeyID)
+				assert.Equal(t, "shared-sk", cred.accessKeySecret)
+				assert.Equal(t, "shared-token", cred.stsToken)
+			},
+		},
+		{
+			name:   "compat: legacy ALIBABA_CLOUD_CREDENTIALS_FILE env var still works",
+			config: nil,
+			setupEnv: func(t *testing.T) map[string]string {
+				// Legacy path: file path via env var (no config key)
+				tmpDir, err := os.MkdirTemp("", "test-legacy-env-file")
+				require.NoError(t, err)
+
+				credFile := filepath.Join(tmpDir, "credentials")
+				err = os.WriteFile(credFile, []byte(`ALIBABA_CLOUD_ACCESS_KEY_ID=legacy-file-ak
+ALIBABA_CLOUD_ACCESS_KEY_SECRET=legacy-file-sk
+`), 0644)
+				require.NoError(t, err)
+
+				t.Setenv("ALIBABA_CLOUD_CREDENTIALS_FILE", credFile)
+				t.Setenv("ALIBABA_CLOUD_ACCESS_KEY_ID", "")
+				t.Setenv("ALIBABA_CLOUD_ACCESS_KEY_SECRET", "")
+				t.Setenv("ALIBABA_CLOUD_ACCESS_STS_TOKEN", "")
+
+				t.Cleanup(func() { os.RemoveAll(tmpDir) })
+				return nil
+			},
+			validateCred: func(t *testing.T, cred *ossCredentials) {
+				assert.Equal(t, "legacy-file-ak", cred.accessKeyID)
+				assert.Equal(t, "legacy-file-sk", cred.accessKeySecret)
+			},
+		},
+		{
+			name:   "compat: config credentialsFile takes precedence over env CREDENTIALS_FILE",
+			config: nil,
+			setupEnv: func(t *testing.T) map[string]string {
+				tmpDir, err := os.MkdirTemp("", "test-config-over-env")
+				require.NoError(t, err)
+
+				// File referenced by env var
+				envFile := filepath.Join(tmpDir, "env-credentials")
+				err = os.WriteFile(envFile, []byte(`ALIBABA_CLOUD_ACCESS_KEY_ID=env-file-ak
+ALIBABA_CLOUD_ACCESS_KEY_SECRET=env-file-sk
+`), 0644)
+				require.NoError(t, err)
+
+				// File referenced by config key (should win)
+				configFile := filepath.Join(tmpDir, "config-credentials")
+				err = os.WriteFile(configFile, []byte(`ALIBABA_CLOUD_ACCESS_KEY_ID=config-file-ak
+ALIBABA_CLOUD_ACCESS_KEY_SECRET=config-file-sk
+`), 0644)
+				require.NoError(t, err)
+
+				t.Setenv("ALIBABA_CLOUD_CREDENTIALS_FILE", envFile)
+				t.Setenv("ALIBABA_CLOUD_ACCESS_KEY_ID", "")
+				t.Setenv("ALIBABA_CLOUD_ACCESS_KEY_SECRET", "")
+				t.Setenv("ALIBABA_CLOUD_ACCESS_STS_TOKEN", "")
+
+				t.Cleanup(func() { os.RemoveAll(tmpDir) })
+				return map[string]string{"credentialsFile": configFile}
+			},
+			validateCred: func(t *testing.T, cred *ossCredentials) {
+				assert.Equal(t, "config-file-ak", cred.accessKeyID)
+				assert.Equal(t, "config-file-sk", cred.accessKeySecret)
+			},
 		},
 	}
 


### PR DESCRIPTION
Replace godotenv.Overload with godotenv.Read in getCredentials to avoid polluting process-wide environment variables. This enables proper per-location credential isolation when BSL and VSL reference different Kubernetes Secrets via spec.credential.

Previously, loading a credentials file via godotenv.Overload would call os.Setenv, permanently mutating the process environment. This caused a bug where BSL credentials leaked into VSL when VSL had no credentials file configured (it would pick up BSL's stale env vars instead of falling through to RAM Role).

Changes:
- Replace loadCredentialFileFromEnv (godotenv.Overload) with getCredFilePath + readCredentialFile (godotenv.Read)
- When credentialsFile is present, read into a local map only
- When no credentialsFile, fall back to process env vars as before
- Extract env var names into constants (envAccessKeyID, etc.)
- Fix typo in error message (credientials -> credentials)

Behavior changes:
- credentialsFile no longer leaks into other plugin instances
- Partial credentials in file (e.g. AK without SK) no longer combine with process env vars; the file is authoritative for that location

Tested on ACK cluster with:
- BSL using spec.credential -> oss-secret (static AK)
- VSL using ECS instance RAM Role (no spec.credential)
- Both paths work independently without interference